### PR TITLE
Updated the method `displayText` to use `getbbox` instead of `getsize` for calculating the text dimensions.

### DIFF
--- a/KitronikAirQualityControlHAT.py
+++ b/KitronikAirQualityControlHAT.py
@@ -382,7 +382,7 @@ class KitronikOLED():
         if line < 1: line = 1
         if line > 6: line = 6
         y = (line * 11) - 10
-        (font_width, font_height) = self.font.getsize(text)
+        (font_width, font_height) = self.font.getbbox(text)[2:4]
         self.draw.text((x_offset, y), text, font = self.font, fill = 1)
 
     # Make what has been set to display actually appear on the screen


### PR DESCRIPTION
This pull request includes a small change to the `displayText` method in the `KitronikAirQualityControlHAT.py` file. The change updates the way font dimensions are calculated to use the `getbbox` method instead of the `getsize` method.

* [`KitronikAirQualityControlHAT.py`](diffhunk://#diff-8f011d8e323ae8332993da9eb19aa4eaf36472cfb1acfbc6413a7031ce1757c2L385-R385): Modified the `displayText` method to use `self.font.getbbox(text)[2:4]` for calculating `font_width` and `font_height` instead of `self.font.getsize(text)`.

Here is the updated code for the `displayText` method in the `KitronikAirQualityControlHAT.py` file:

```python
# ...
# Set text to display on a particular line (1 - 6) and an x-axis offset can be set (0 - 127, 0 is default)
# If the text is longer than the screen it will be cut off, it will not be pushed to the next line (16 characters max per line)
# Need to call 'show()' to make the text actually display
def displayText(self, text, line, x_offset=0):
    if line < 1:
        line = 1
    if line > 6:
        line = 6
    y = (line * 11) - 10
    # (font_width, font_height) = self.font.getsize(text)  # Deprecated
    (font_width, font_height) = self.font.getbbox(text)[2:4]  # Updated to getbbox
    self.draw.text((x_offset, y), text, font=self.font, fill=1)
    # Note: Pillow no longer supports the getsize method for font metrics; use getbbox instead.
# ...
```